### PR TITLE
Update README.md - Add zELF: A modular ELF64 packer for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@
 - [Ward](https://github.com/ex0dus-0x/ward) - Simple implementation of an ELF packer that creates stealthy droppers for loading malicious ELFs in-memory.
 - [Woody Wood Packer](https://github.com/Jibus22/woody_woodpacker) - ELF packer - encrypt and inject self-decryption code into executable ELF binary target.
 - [xorPacker](https://github.com/nqntmqmqmb/xorPacker) - Simple packer working with all PE files which cipher your exe with a XOR implementation.
+* [zELF](https://github.com/seb3773/zelf) - A modular ELF64 packer for Linux x86_64 featuring 22 compression codecs, ML-based codec selection, and support for both static and PIE binaries.
 - [ZProtect](http://www.jiami.net) - Renames metadata entities and supports advanced obfuscation methods that harden protection scheme and foil reverse engineering altogether.
 
 <p align="center"><a href="#top"><img src="https://img.shields.io/badge/Back%20to%20top--lightgrey?style=social" alt="Back to top" height="20"/></a></p>


### PR DESCRIPTION
### Description
Hi! I would like to propose adding **zELF** to the list of Linux-specific packers.

zELF is a highly modular ELF64 packer for Linux x86_64. Unlike many traditional packers, it offers:
- **Modular architecture:** Includes 22 compression codecs with the ability to integrate custom ones.
- **Smart selection:** Uses ML models to automatically select the best codec for a given binary.
- **Versatility:** Handles both static and dynamic/PIE binaries.
- **Optimization:** Features advanced filtering (BCJ, KanziEXE) and brute-force modes (`-best`, `-crazy`) to maximize compression ratios.
- **Heritage & Efficiency:** It integrates several "vintage" codecs (originating from the 8-bit era). This serves as both an homage to classic computing and a technical optimization: these codecs were designed for highly constrained environments, making some of them ideal for keeping decompression stubs small and efficient, even nowadays.

Beyond its features, it is designed with a **pedagogical approach** to help developers and security researchers understand the intricacies of the ELF64 structure and binary instrumentation.

It is a modern and actively maintained tool that fits within the "Linux" section of this awesome list.

### Checklist
- [x] The project is Open Source.
- [x] The link is placed in alphabetical order (if applicable) or under the correct category.
- [x] The description is concise and objective.

url: https://github.com/seb3773/zelf

Thank you for maintaining this great resource!

seb3773